### PR TITLE
support showing multiple collaborators in a credit list

### DIFF
--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -1,7 +1,8 @@
 // TODO: Create a function that returns a license badge based on which license is passed in
 // If there is no license, return an empty string
 function renderLicenseBadge(license) {
-
+  return `![badge](https://img.shields.io/badge/license-${license}-brightgreen)`
+  //generate badge link https://img.shields.io/github/license/<Github-Username>/<Repository>
 }
 
 // TODO: Create a function that returns the license link
@@ -16,46 +17,86 @@ function renderLicenseSection(license) {
 
 }
 
-// TODO: Create a function to generate markdown for README
-function generateMarkdown(data) {
-  let markdown = [];
-  markdown.push('# ' + data.title);
+function generateTitle(title) {
+  const result = '# ' + title
+  return result;
+}
 
-  const description = '## Description';
-  markdown.push(`${description}\n\n${data.description}`);
+function generateDescription(description) {
+  const descriptionEl = '## Description';
+  const result = `${descriptionEl}\n\n${description}`;
+  return result;
+}
+
+function generateTableOfContents(credit) {
 
   const tableOfContents = '## Table of Contents';
   const tableList1 = '- [Installation](#installation)';
   const tableList2 = '- [Usage](#usage)';
   const tableList3 = '- [Credits](#credits)';
   const tableList4 = '- [License](#license)';
-  markdown.push(`${tableOfContents}\n\n${tableList1}\n${tableList2}\n${tableList3}\n${tableList4}`);
+  return credit ? `${tableOfContents}\n\n${tableList1}\n${tableList2}\n${tableList3}\n${tableList4}` :
+    `${tableOfContents}\n\n${tableList1}\n${tableList2}\n${tableList4}`;
+}
 
-  const installation = '## Installation'
-  markdown.push(`${installation}\n\n${data.installation}`)
+function generateInstallation(installation) {
+  const installationEl = '## Installation';
+  const result = `${installationEl}\n\n${installation}`;
+  return result;
+}
 
-  const usage = '## Usage';
-  const usageText = data.usage;
-  const screenshotDescription = 'Here\'s a screenshot of the project'
-  const screenshot = `![project screenshot](assets/images/${data.screenshot})`;
-  markdown.push(`${usage}\n\n${usageText}\n\n${screenshotDescription}\n\n${screenshot}`)
+function generateUsage(usage, screenshot) {
+  const usageEl = '## Usage';
+  const screenshotDescription = 'Here\'s a screenshot of the project';
+  const screenshotPath = `![project screenshot](assets/images/${screenshot})`;
+  const result = `${usageEl}\n\n${usage}\n\n${screenshotDescription}\n\n${screenshotPath}`;
+  return result;
+}
 
-  if (data.credit) {
-    const credit = '## Credit';
-    markdown.push(`${credit}\n\n${data.credit}`);
+function generateCredit(credit) {
+  if (credit) {
+    const creditEl = '## Credit';
+    const collaboratorArr = credit.split(',').map(ele => ele.trim());
+    let collaboratorStr = [];
+    for (let x = 0; x < collaboratorArr.length; x++) {
+      if (collaboratorArr[x].length > 0) {
+        collaboratorStr += `- ${collaboratorArr[x]}\n`
+      }
+    }
+    const result = `${creditEl}\n\n${collaboratorStr}`;
+    return result;
+  } else {
+    return
   }
+}
 
-  //license + bages
-  if (data.contribute) {
-    const contribute = '## Contribute';
-    markdown.push(`${contribute}\n\n${data.contribute}`);
+function generateContribute(contribute) {
+  if (contribute) {
+    const contributeEl = '## Contribute';
+    const result = `${contributeEl}\n\n${contribute}`;
+    return result;
   }
+}
 
-  if (data.test) {
-    const test = '## Tests';
-    markdown.push(`${test}\n\n${data.test}`);
+function generateTest(test) {
+  if (test) {
+    const testEl = '## Tests';
+    const result = `${testEl}\n\n${test}`;
+    return result;
   }
+}
 
+// TODO: Create a function to generate markdown for README
+function generateMarkdown(data) {
+  let markdown = [];
+  markdown.push(generateTitle(data.title));
+  markdown.push(generateDescription(data.description));
+  markdown.push(generateTableOfContents(data.credit));
+  markdown.push(generateInstallation(data.installation));
+  markdown.push(generateUsage(data.usage, data.screenshot));
+  markdown.push(generateCredit(data.credit));
+  markdown.push(generateContribute(data.contribute));
+  markdown.push(generateTest(data.test));
   return markdown.join('\n\n');
 }
 


### PR DESCRIPTION
* when type in multiple collaborators, the collaborators will show in a list in README
* user separate collaborators with commas, extra comma will be filtered out.
for example:
```
? Please list the github username of your collaborator(s) (if any, seperate with comma; press Enter if doesn't apply):
personA,personB,,,,personC,,personD,,
```
The readme file will look like:
```
## Credit

- personA
- personB
- personC
- personD
```
